### PR TITLE
# Auto-scrolling and Custom Scrollbars for Order Book

### DIFF
--- a/frontend/cypress/e2e/order-book.cy.ts
+++ b/frontend/cypress/e2e/order-book.cy.ts
@@ -78,4 +78,36 @@ describe('Order Book', () => {
       .should('have.attr', 'style')
       .and('include', 'width:')
   })
+
+  it('maintains correct scroll position after initial load', () => {
+    // Check sell orders are scrolled to bottom (or near bottom)
+    cy.get('[data-test="sell-orders"]').then(($el) => {
+      const element = $el[0]
+      const isNearBottom = element.scrollHeight - element.scrollTop - element.clientHeight < 50
+      expect(isNearBottom).to.be.true
+    })
+
+    // Check buy orders are scrolled to top
+    cy.get('[data-test="buy-orders"]').then(($el) => {
+      const isAtTop = $el[0].scrollTop < 50
+      expect(isAtTop).to.be.true
+    })
+  })
+
+  it('maintains correct scroll position after group size change', () => {
+    cy.get('[data-test="group-size-select"] select').select('50')
+
+    // Check sell orders are scrolled to bottom (or near bottom)
+    cy.get('[data-test="sell-orders"]').then(($el) => {
+      const element = $el[0]
+      const isNearBottom = element.scrollHeight - element.scrollTop - element.clientHeight < 50
+      expect(isNearBottom).to.be.true
+    })
+
+    // Check buy orders are scrolled to top
+    cy.get('[data-test="buy-orders"]').then(($el) => {
+      const isAtTop = $el[0].scrollTop < 50
+      expect(isAtTop).to.be.true
+    })
+  })
 })

--- a/frontend/src/features/order-book/components/OrderBook.vue
+++ b/frontend/src/features/order-book/components/OrderBook.vue
@@ -16,7 +16,7 @@ const {
 </script>
 
 <template>
-  <div class="flex flex-col h-full bg-gray-900" data-test="order-book">
+  <div class="flex flex-col h-[800px] bg-gray-900" data-test="order-book">
     <!-- Connection error message -->
     <div v-if="error" class="p-2 bg-red-900/50 text-red-200 text-sm" data-test="error-message">
       Connection error
@@ -48,24 +48,27 @@ const {
       <div class="text-right">Total (BTC)</div>
     </div>
 
-    <!-- Sells/Asks -->
-    <div class="flex-1 overflow-auto" data-test="sell-orders">
-      <div
-        v-for="order in sellOrders"
-        :key="order.price"
-        class="grid grid-cols-3 px-4 py-1 text-sm relative group order-row"
-      >
+    <!-- Sells/Asks - Fixed height with scroll -->
+    <div class="h-[300px] overflow-auto scrollbar" data-test="sell-orders">
+      <div class="flex flex-col-reverse">
+        <!-- Reverse to show lowest sells at bottom -->
         <div
-          class="absolute inset-0 bg-red-900/40"
-          :style="{ width: `${order.depth}%`, right: 0 }"
-        ></div>
-        <div class="relative text-left text-red-400 price">{{ formatPrice(order.price) }}</div>
-        <div class="relative text-right text-white amount">{{ formatAmount(order.amount) }}</div>
-        <div class="relative text-right text-white total">{{ formatAmount(order.total) }}</div>
+          v-for="order in sellOrders"
+          :key="order.price"
+          class="grid grid-cols-3 px-4 py-1 text-sm relative group order-row"
+        >
+          <div
+            class="absolute inset-0 bg-red-900/40"
+            :style="{ width: `${order.depth}%`, right: 0 }"
+          ></div>
+          <div class="relative text-left text-red-400 price">{{ formatPrice(order.price) }}</div>
+          <div class="relative text-right text-white amount">{{ formatAmount(order.amount) }}</div>
+          <div class="relative text-right text-white total">{{ formatAmount(order.total) }}</div>
+        </div>
       </div>
     </div>
 
-    <!-- Mark Price -->
+    <!-- Mark Price - stays fixed -->
     <div
       class="flex items-center justify-between px-4 py-1.5 border-y border-gray-800/50 bg-gray-900/50"
       data-test="mark-price"
@@ -74,8 +77,8 @@ const {
       <div class="text-gray-400">Mark: {{ markPrice !== null ? formatPrice(markPrice) : '—' }}</div>
     </div>
 
-    <!-- Buys/Bids -->
-    <div class="flex-1 overflow-auto" data-test="buy-orders">
+    <!-- Buys/Bids - Fixed height with scroll -->
+    <div class="h-[300px] overflow-auto scrollbar" data-test="buy-orders">
       <div
         v-for="order in buyOrders"
         :key="order.price"
@@ -92,3 +95,29 @@ const {
     </div>
   </div>
 </template>
+
+<style scoped>
+.scrollbar {
+  /* For Webkit browsers (Chrome, Safari) */
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #374151; /* gray-700 */
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #9ca3af; /* gray-400 */
+    border-radius: 3px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: #d1d5db; /* gray-300 */
+  }
+
+  /* For Firefox */
+  scrollbar-width: thin;
+  scrollbar-color: #9ca3af #374151;
+}
+</style>

--- a/frontend/src/features/order-book/components/OrderBook.vue
+++ b/frontend/src/features/order-book/components/OrderBook.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { onMounted } from 'vue'
 import { useOrderBook } from '../composables/useOrderBook'
 import GroupSizeSelect from './GroupSizeSelect.vue'
 
@@ -12,7 +13,12 @@ const {
   formatAmount,
   groupSize,
   groupSizeOptions,
+  scrollOrdersToCenter,
 } = useOrderBook()
+
+onMounted(() => {
+  scrollOrdersToCenter()
+})
 </script>
 
 <template>
@@ -36,7 +42,7 @@ const {
       <div class="text-lg">Order Book</div>
       <GroupSizeSelect
         v-model="groupSize"
-        :options="[...groupSizeOptions]"
+        :options="groupSizeOptions"
         data-test="group-size-select"
       />
     </div>
@@ -97,26 +103,25 @@ const {
 </template>
 
 <style scoped>
+.scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scrollbar::-webkit-scrollbar-track {
+  background: #374151; /* gray-700 */
+}
+
+.scrollbar::-webkit-scrollbar-thumb {
+  background: #9ca3af; /* gray-400 */
+  border-radius: 3px;
+}
+
+.scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #d1d5db; /* gray-300 */
+}
+
+/* Firefox */
 .scrollbar {
-  /* For Webkit browsers (Chrome, Safari) */
-  &::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: #374151; /* gray-700 */
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: #9ca3af; /* gray-400 */
-    border-radius: 3px;
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background: #d1d5db; /* gray-300 */
-  }
-
-  /* For Firefox */
   scrollbar-width: thin;
   scrollbar-color: #9ca3af #374151;
 }

--- a/frontend/src/features/order-book/components/__tests__/OrderBook.test.ts
+++ b/frontend/src/features/order-book/components/__tests__/OrderBook.test.ts
@@ -30,6 +30,7 @@ vi.mock('../../composables/useOrderBook', () => ({
       }),
     groupSize: ref(0.5),
     groupSizeOptions: [0.5, 1, 2.5, 5, 10, 25, 50, 100],
+    scrollOrdersToCenter: vi.fn(),
   }),
 }))
 
@@ -37,6 +38,7 @@ describe('OrderBook', () => {
   let wrapper: ReturnType<typeof mount>
 
   beforeEach(() => {
+    document.body.innerHTML = ''
     wrapper = mount(OrderBook)
   })
 
@@ -45,7 +47,7 @@ describe('OrderBook', () => {
   })
 
   it('displays sell orders correctly', () => {
-    const sellOrderRows = wrapper.findAll('.flex-1 .text-red-400')
+    const sellOrderRows = wrapper.findAll('[data-test="sell-orders"] .price')
     expect(sellOrderRows).toHaveLength(2)
 
     const sellPrices = sellOrderRows.map((el) => el.text())
@@ -53,12 +55,12 @@ describe('OrderBook', () => {
   })
 
   it('displays buy orders correctly', () => {
-    const buyOrders = wrapper.findAll('.text-green-400')
+    const buyOrders = wrapper.findAll('[data-test="buy-orders"] .price')
     expect(buyOrders).toHaveLength(2)
     expect(buyOrders[0].text()).toBe('20,000.00')
   })
 
   it('shows mark price', () => {
-    expect(wrapper.text()).toContain('Mark: 20,050.00')
+    expect(wrapper.find('[data-test="mark-price"]').text()).toContain('20,050.00')
   })
 })

--- a/frontend/src/features/order-book/composables/useOrderBook.ts
+++ b/frontend/src/features/order-book/composables/useOrderBook.ts
@@ -1,4 +1,4 @@
-import { ref, watch, computed } from 'vue'
+import { ref, watch, computed, nextTick } from 'vue'
 import { useWebSocket } from '../../../features/websocket/composables/useWebSocket'
 import type { Order, GroupSize, GroupedOrder } from '../types'
 
@@ -14,6 +14,9 @@ export function useOrderBook() {
 
     if (newData.existing) {
       orders.value = newData.existing
+      nextTick(() => {
+        scrollOrdersToCenter()
+      })
     }
     if (newData.insert) {
       orders.value = [...orders.value, ...newData.insert]
@@ -22,6 +25,24 @@ export function useOrderBook() {
       orders.value = orders.value.filter((order) => !newData.delete?.includes(order.id))
     }
   })
+
+  watch(groupSize, () => {
+    nextTick(() => {
+      scrollOrdersToCenter()
+    })
+  })
+
+  const scrollOrdersToCenter = () => {
+    const sellContainer = document.querySelector('[data-test="sell-orders"]')
+    const buyContainer = document.querySelector('[data-test="buy-orders"]')
+
+    if (sellContainer) {
+      sellContainer.scrollTop = sellContainer.scrollHeight
+    }
+    if (buyContainer) {
+      buyContainer.scrollTop = 0
+    }
+  }
 
   const groupOrders = (orders: Order[], side: 'buy' | 'sell'): GroupedOrder[] => {
     const filtered = orders.filter((order) => order.side === side)
@@ -94,5 +115,6 @@ export function useOrderBook() {
     markPrice,
     formatPrice,
     formatAmount,
+    scrollOrdersToCenter,
   }
 }


### PR DESCRIPTION
## Changes
- Implemented auto-scrolling functionality to keep best orders visible
- Added custom scrollbar styling with cross-browser support
- Enhanced test coverage for scroll behavior

## Technical Details
- Auto-scroll keeps best buy/sell orders adjacent to mark price
- Triggers on:
  - Initial data load
  - Group size changes
- Custom scrollbar implementation:
  - WebKit (Chrome/Safari) support
  - Firefox support
  - Consistent with app theme
  - 6px width with hover effect

## Testing
- Added Cypress tests for scroll position verification
- Updated unit tests with scroll behavior mocks
- Implemented resilient position checks to handle data variations